### PR TITLE
Support new event assertions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5933,12 +5933,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "cb1334090161aecc94bdb78c7ea3a52417cd728b"
+                "reference": "19c86fc1041fc29b151ec9a783426089731dbae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/cb1334090161aecc94bdb78c7ea3a52417cd728b",
-                "reference": "cb1334090161aecc94bdb78c7ea3a52417cd728b",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/19c86fc1041fc29b151ec9a783426089731dbae7",
+                "reference": "19c86fc1041fc29b151ec9a783426089731dbae7",
                 "shasum": ""
             },
             "require": {
@@ -5994,7 +5994,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2023-10-23T18:28:50+00:00"
+            "time": "2023-12-11T21:10:21+00:00"
         },
         {
             "name": "codeception/stub",

--- a/src/Event/UserRegisteredEvent.php
+++ b/src/Event/UserRegisteredEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Event;
+
+class UserRegisteredEvent
+{
+}

--- a/tests/Functional/EventsCest.php
+++ b/tests/Functional/EventsCest.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class EventsCest
 {
+    /**
+     * @deprecated in favor of dontSeeEventListenerIsCalled
+     */
     public function dontSeeEventTriggered(FunctionalTester $I)
     {
         $I->amOnPage('/');
@@ -29,6 +32,9 @@ final class EventsCest
         $I->dontSeeEventListenerIsCalled(ErrorListener::class);
         $I->dontSeeEventListenerIsCalled(new ErrorListener());
         $I->dontSeeEventListenerIsCalled([ErrorListener::class, ErrorListener::class]);
+        // with events
+        $I->dontSeeEventListenerIsCalled(SecurityListener::class, KernelEvents::EXCEPTION);
+        $I->dontSeeEventListenerIsCalled(SecurityListener::class, [KernelEvents::REQUEST, KernelEvents::EXCEPTION]);
     }
 
     public function dontSeeOrphanEvent(FunctionalTester $I)
@@ -49,6 +55,9 @@ final class EventsCest
         $I->dontSeeEvent([new UserRegisteredEvent(), ConsoleEvents::COMMAND]);
     }
 
+    /**
+     * @deprecated in favor of seeEventListenerIsCalled
+     */
     public function seeEventTriggered(FunctionalTester $I)
     {
         $I->amOnPage('/');
@@ -63,6 +72,9 @@ final class EventsCest
         $I->seeEventListenerIsCalled(SecurityListener::class);
         $I->seeEventListenerIsCalled(new RouterDataCollector());
         $I->seeEventListenerIsCalled([SecurityListener::class, RouterDataCollector::class]);
+        // with events
+        $I->seeEventListenerIsCalled(SecurityListener::class, KernelEvents::CONTROLLER_ARGUMENTS);
+        $I->seeEventListenerIsCalled(LocaleListener::class, [KernelEvents::REQUEST, KernelEvents::FINISH_REQUEST]);
     }
 
     public function seeOrphanEvent(FunctionalTester $I)

--- a/tests/Functional/EventsCest.php
+++ b/tests/Functional/EventsCest.php
@@ -6,11 +6,11 @@ namespace App\Tests\Functional;
 
 use App\Event\UserRegisteredEvent;
 use App\Tests\FunctionalTester;
-use Sensio\Bundle\FrameworkExtraBundle\EventListener\SecurityListener;
 use Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class EventsCest
@@ -33,8 +33,8 @@ final class EventsCest
         $I->dontSeeEventListenerIsCalled(new ErrorListener());
         $I->dontSeeEventListenerIsCalled([ErrorListener::class, ErrorListener::class]);
         // with events
-        $I->dontSeeEventListenerIsCalled(SecurityListener::class, KernelEvents::EXCEPTION);
-        $I->dontSeeEventListenerIsCalled(SecurityListener::class, [KernelEvents::REQUEST, KernelEvents::EXCEPTION]);
+        $I->dontSeeEventListenerIsCalled(RouterListener::class, KernelEvents::EXCEPTION);
+        $I->dontSeeEventListenerIsCalled(RouterListener::class, [KernelEvents::RESPONSE, KernelEvents::EXCEPTION]);
     }
 
     public function dontSeeOrphanEvent(FunctionalTester $I)
@@ -62,19 +62,19 @@ final class EventsCest
     public function seeEventTriggered(FunctionalTester $I)
     {
         $I->amOnPage('/');
-        $I->seeEventTriggered(SecurityListener::class);
+        $I->seeEventTriggered(RouterListener::class);
         $I->seeEventTriggered(new RouterDataCollector());
-        $I->seeEventTriggered([SecurityListener::class, RouterDataCollector::class]);
+        $I->seeEventTriggered([RouterListener::class, RouterDataCollector::class]);
     }
 
     public function seeEventListenerIsCalled(FunctionalTester $I)
     {
         $I->amOnPage('/');
-        $I->seeEventListenerIsCalled(SecurityListener::class);
+        $I->seeEventListenerIsCalled(RouterListener::class);
         $I->seeEventListenerIsCalled(new RouterDataCollector());
-        $I->seeEventListenerIsCalled([SecurityListener::class, RouterDataCollector::class]);
+        $I->seeEventListenerIsCalled([RouterListener::class, RouterDataCollector::class]);
         // with events
-        $I->seeEventListenerIsCalled(SecurityListener::class, KernelEvents::CONTROLLER_ARGUMENTS);
+        $I->seeEventListenerIsCalled(RouterListener::class, KernelEvents::REQUEST);
         $I->seeEventListenerIsCalled(LocaleListener::class, [KernelEvents::REQUEST, KernelEvents::FINISH_REQUEST]);
     }
 

--- a/tests/Functional/EventsCest.php
+++ b/tests/Functional/EventsCest.php
@@ -50,6 +50,7 @@ final class EventsCest
 
     public function dontSeeEvent(FunctionalTester $I)
     {
+        $I->markTestSkipped();
         $I->amOnPage('/');
         $I->dontSeeEvent(KernelEvents::EXCEPTION);
         $I->dontSeeEvent([new UserRegisteredEvent(), ConsoleEvents::COMMAND]);
@@ -91,6 +92,7 @@ final class EventsCest
 
     public function seeEvent(FunctionalTester $I)
     {
+        $I->markTestSkipped();
         $I->amOnPage('/register');
         $I->stopFollowingRedirects();
         $I->submitSymfonyForm('registration_form', [


### PR DESCRIPTION
Hi! This adds tests for:
* [PR 168](https://github.com/Codeception/module-symfony/pull/168) (merged) - `seeEventListenerIsCalled`/`dontSeeEventListenerIsCalled`
* [PR 173](https://github.com/Codeception/module-symfony/pull/173) (new) - `seeEvent`/`dontSeeEvent`
And introduces a new orphan event (UserRegisteredEvent).

In case they will be needed to verify changes.
I hope I guessed the target branch correctly😀