### PR TITLE
Ensure fragments are ignored when parsing URLs for routes

### DIFF
--- a/tests/Functional/IssuesCest.php
+++ b/tests/Functional/IssuesCest.php
@@ -32,4 +32,14 @@ final class IssuesCest
         $user = $dbalConnection->fetchOne('SELECT id FROM user WHERE email = :email', ['email' => 'fixture@fixture.test']);
         $I->assertNotFalse($user);
     }
+
+   /**
+     * @see https://github.com/Codeception/module-symfony/pull/185
+     */
+    public function ensureFragmentsAreIgnored(FunctionalTester $I)
+    {
+        $I->amOnPage('/register#content');
+        $I->seeInCurrentRoute('app_register');
+        $I->seeCurrentRouteIs('app_register');
+    }
 }

--- a/tests/Support/_generated/FunctionalTesterActions.php
+++ b/tests/Support/_generated/FunctionalTesterActions.php
@@ -1,4 +1,4 @@
-<?php  //[STAMP] efac700459e2b7caae8b963946103bb9
+<?php  //[STAMP] 2e00904c0bf7be59daddd1dfc51d2b6d
 // phpcs:ignoreFile
 namespace App\Tests\Support\_generated;
 


### PR DESCRIPTION
https://github.com/Codeception/module-symfony/pull/185

No idea why but Codeception gets the failing test information completely wrong:

```
There was 1 failure:
1) EventsCest: See event
 Test  tests/Functional/EventsCest.php:seeEvent
 Step  See event "non-existent-event"
 Fail  The "/register#content" url does not match with any route

Scenario Steps:

 7. $I->assertTrue(true,"seeEvent assertion fails with non-existent events.") at tests/Functional/EventsCest.php:107
 6. $I->seeEvent("non-existent-event") at tests/Functional/EventsCest.php:105
 5. $I->seeEvent("kernel.request","kernel.finish_request") at tests/Functional/EventsCest.php:103
 4. $I->seeEvent("App\Event\UserRegisteredEvent") at tests/Functional/EventsCest.php:102
 3. $I->submitSymfonyForm("registration_form",{"[email]":"jane_doe@gmail.com","[plainPassword]":"123456","[agreeTerms]":true}) at tests/Functional/EventsCest.php:98
 2. $I->stopFollowingRedirects() at tests/Functional/EventsCest.php:96
```