### PR TITLE
Add command requiring user input and test passing console input works

### DIFF
--- a/src/Command/AskForInputCommand.php
+++ b/src/Command/AskForInputCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+#[AsCommand('app:ask-for-input', 'An example command asking for user input.')]
+final class AskForInputCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $helper = $this->getHelper('question');
+
+        $question = new ConfirmationQuestion('continue?', false);
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('bye');
+
+            return Command::FAILURE;
+        }
+
+        $question = new Question('input');
+        $answer = $helper->ask($input, $output, $question);
+
+        $output->writeln("user input: '$answer'");
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Functional/ConsoleCest.php
+++ b/tests/Functional/ConsoleCest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional;
 
+use App\Command\AskForInputCommand;
 use App\Command\ExampleCommand;
 use App\Tests\Support\FunctionalTester;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\MissingInputException;
 
 final class ConsoleCest
 {
-    public function runSymfonyConsoleCommand(FunctionalTester $I)
+    public function runSymfonyConsoleCommand(FunctionalTester $I): void
     {
         // Call Symfony console without option
         $output = $I->runSymfonyConsoleCommand(ExampleCommand::getDefaultName());
@@ -28,5 +31,32 @@ final class ConsoleCest
             ['--something' => true]
         );
         $I->assertStringContainsString('Bye world!', $output);
+    }
+
+    public function runSymfonyConsoleCommandInput(FunctionalTester $I): void
+    {
+        // Confirmation question not confirmed
+        $output = $I->runSymfonyConsoleCommand(
+            AskForInputCommand::getDefaultName(),
+            consoleInputs: ['n'],
+            expectedExitCode: Command::FAILURE,
+        );
+        $I->assertStringContainsString('bye', $output);
+
+        // Exception on missing input
+        $I->expectThrowable(
+            MissingInputException::class,
+            fn () => $I->runSymfonyConsoleCommand(
+                AskForInputCommand::getDefaultName(),
+                consoleInputs: ['y'],
+            ),
+        );
+
+        // Multiple inputs
+        $output = $I->runSymfonyConsoleCommand(
+            AskForInputCommand::getDefaultName(),
+            consoleInputs: ['y', 'foobar'],
+        );
+        $I->assertStringContainsString("user input: 'foobar'", $output);
     }
 }


### PR DESCRIPTION
Inspired by the discussion at https://github.com/Codeception/module-symfony/pull/204

When I saw the question in the linked PR about passing inputs to commands not working I already tested this and it worked, so since now the question came up again, I thought adding some tests here, demonstrating that/how it works might be a good idea.

Symfony docs can be found at https://symfony.com/doc/current/components/console/helpers/questionhelper.html