### PR TITLE
[5.4] Expect throwable in notifier cest 

### DIFF
--- a/tests/Functional/NotifierCest.php
+++ b/tests/Functional/NotifierCest.php
@@ -5,62 +5,79 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Tests\Support\FunctionalTester;
+use PHPUnit\Framework\Error\Warning;
 
 final class NotifierCest
 {
     public function assertNotificationSubjectContains(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notification = $I->getNotifierMessage();
-        $I->assertNotificationSubjectContains($notification, 'created!');
+        $I->expectThrowable(Warning::class, function () {
+            $notification = $I->getNotifierMessage();
+            $I->assertNotificationSubjectContains($notification, 'created!');
+        });
     }
 
     public function assertNotificationSubjectNotContains(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notification = $I->getNotifierMessage();
-        $I->assertNotificationSubjectNotContains($notification, 'Account not created!');
+        $I->expectThrowable(Warning::class, function () {
+            $notification = $I->getNotifierMessage();
+            $I->assertNotificationSubjectNotContains($notification, 'Account not created!');
+        });
     }
 
     public function assertNotificationTransportIsEqual(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notification = $I->getNotifierMessage();
-        $I->assertNotificationTransportIsEqual($notification);
+        $I->expectThrowable(Warning::class, function () {
+            $notification = $I->getNotifierMessage();
+            $I->assertNotificationTransportIsEqual($notification);
+        });
     }
 
     public function assertNotificationTransportIsNotEqual(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notification = $I->getNotifierMessage();
-        $I->assertNotificationTransportIsNotEqual($notification, 'chat');
+        $I->expectThrowable(Warning::class, function () {
+            $notification = $I->getNotifierMessage();
+            $I->assertNotificationTransportIsNotEqual($notification, 'chat');
+        });
     }
 
     public function dontSeeNotificationIsSent(FunctionalTester $I)
     {
         $I->registerUser('john_doe@gmail.com', '123456', followRedirects: false);
-        // There is already an account with this notification
-        $I->dontSeeNotificationIsSent();
+        $I->expectThrowable(Warning::class, function () {
+            // There is already an account with this notification
+            $I->dontSeeNotificationIsSent();
+        });
     }
 
     public function grabLastSentNotification(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notification = $I->grabLastSentNotification();
-        $I->assertSame('Account created!', $notification->getSubject());
+        $I->expectThrowable(Warning::class, function () {
+            $notification = $I->grabLastSentNotification();
+            $I->assertSame('Account created!', $notification->getSubject());
+        });
     }
 
     public function grabSentNotifications(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $notifications = $I->grabSentNotifications();
-        $subject = $notifications[0]->getSubject();
-        $I->assertSame('Account created!', $subject);
+        $I->expectThrowable(Warning::class, function () {
+            $notifications = $I->grabSentNotifications();
+            $subject = $notifications[0]->getSubject();
+            $I->assertSame('Account created!', $subject);
+        });
     }
 
     public function seeNotificationIsSent(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->seeNotificationIsSent();
+        $I->expectThrowable(Warning::class, function () {
+            $I->seeNotificationIsSent();
+        });
     }
 }

--- a/tests/Functional/NotifierCest.php
+++ b/tests/Functional/NotifierCest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Tests\Support\FunctionalTester;
-use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\AssertionFailedError;
 
 final class NotifierCest
 {
     public function assertNotificationSubjectContains(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notification = $I->getNotifierMessage();
             $I->assertNotificationSubjectContains($notification, 'created!');
         });
@@ -21,7 +21,7 @@ final class NotifierCest
     public function assertNotificationSubjectNotContains(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notification = $I->getNotifierMessage();
             $I->assertNotificationSubjectNotContains($notification, 'Account not created!');
         });
@@ -30,7 +30,7 @@ final class NotifierCest
     public function assertNotificationTransportIsEqual(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notification = $I->getNotifierMessage();
             $I->assertNotificationTransportIsEqual($notification);
         });
@@ -39,7 +39,7 @@ final class NotifierCest
     public function assertNotificationTransportIsNotEqual(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notification = $I->getNotifierMessage();
             $I->assertNotificationTransportIsNotEqual($notification, 'chat');
         });
@@ -48,7 +48,7 @@ final class NotifierCest
     public function dontSeeNotificationIsSent(FunctionalTester $I)
     {
         $I->registerUser('john_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             // There is already an account with this notification
             $I->dontSeeNotificationIsSent();
         });
@@ -57,7 +57,7 @@ final class NotifierCest
     public function grabLastSentNotification(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notification = $I->grabLastSentNotification();
             $I->assertSame('Account created!', $notification->getSubject());
         });
@@ -66,7 +66,7 @@ final class NotifierCest
     public function grabSentNotifications(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $notifications = $I->grabSentNotifications();
             $subject = $notifications[0]->getSubject();
             $I->assertSame('Account created!', $subject);
@@ -76,7 +76,7 @@ final class NotifierCest
     public function seeNotificationIsSent(FunctionalTester $I)
     {
         $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
-        $I->expectThrowable(Warning::class, function () {
+        $I->expectThrowable(AssertionFailedError::class, function () use ($I) {
             $I->seeNotificationIsSent();
         });
     }


### PR DESCRIPTION
Added checks for throwable in notifier cest for version 5.4, based on [this discussion.](https://github.com/Codeception/module-symfony/pull/220#issuecomment-3587331091)

Not sure why but `ExpectationFailedException` was not thrown, instead it was `AssertionFailedError`