### PR TITLE
[8.1] Add regression tests for Doctrine listener security/request context

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5771,12 +5771,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "250f6286aec8152d39d9e575e0874454f92740fc"
+                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/250f6286aec8152d39d9e575e0874454f92740fc",
-                "reference": "250f6286aec8152d39d9e575e0874454f92740fc",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/6cd215032d717b290a80e45037fe6cac54ec6387",
+                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387",
                 "shasum": ""
             },
             "require": {
@@ -5789,7 +5789,7 @@
                 "codeception/module-doctrine": "^3.3",
                 "doctrine/orm": "^3.6",
                 "friendsofphp/php-cs-fixer": "^3.94",
-                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^11.0 | ^12.0",
                 "symfony/browser-kit": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/cache": "^5.4 | ^6.4 | ^7.4 | ^8.0",
@@ -5869,7 +5869,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-15T13:47:58+00:00"
+            "time": "2026-06-22T17:15:57+00:00"
         },
         {
             "name": "codeception/stub",
@@ -6814,16 +6814,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.8",
+            "version": "v3.95.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "4140023f552ff02346df9b1329742532166f677f"
+                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4140023f552ff02346df9b1329742532166f677f",
-                "reference": "4140023f552ff02346df9b1329742532166f677f",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/93e1ab3e1f153024bd3ab23c8a349556063c6f17",
+                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17",
                 "shasum": ""
             },
             "require": {
@@ -6907,7 +6907,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.8"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.10"
             },
             "funding": [
                 {
@@ -6915,7 +6915,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-16T09:52:26+00:00"
+            "time": "2026-06-19T14:45:22+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -6981,16 +6981,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.1",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
-                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -7080,7 +7080,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -7096,7 +7096,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-12T21:50:12+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -7415,12 +7415,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "93f1757f38c0a5cb0b8c2131761e1266d37b8c50"
+                "reference": "2a9217f60aaf27bf6ddad9188f254d020ab70745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/93f1757f38c0a5cb0b8c2131761e1266d37b8c50",
-                "reference": "93f1757f38c0a5cb0b8c2131761e1266d37b8c50",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/2a9217f60aaf27bf6ddad9188f254d020ab70745",
+                "reference": "2a9217f60aaf27bf6ddad9188f254d020ab70745",
                 "shasum": ""
             },
             "require": {
@@ -7439,7 +7439,7 @@
                 "friendsofphp/php-cs-fixer": "^3.57",
                 "gregwar/rst": "^1.0",
                 "mikey179/vfsstream": "^1.6.8",
-                "phpstan/phpstan": "~2.1.44",
+                "phpstan/phpstan": "~2.1.56",
                 "phpunit/phpunit": "^10.5.62|^11.5.50",
                 "squizlabs/php_codesniffer": "^3.8.0"
             },
@@ -7496,7 +7496,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T20:44:28+00:00"
+            "time": "2026-06-16T19:47:51+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -8840,12 +8840,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "810e1d8cfbc718df8dacf74b62b7b9a1780b9698"
+                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/810e1d8cfbc718df8dacf74b62b7b9a1780b9698",
-                "reference": "810e1d8cfbc718df8dacf74b62b7b9a1780b9698",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/55f7461997e52f12c93d307ccdcb0ee8e89f336a",
+                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a",
                 "shasum": ""
             },
             "conflict": {
@@ -8946,13 +8946,14 @@
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cadmium-org/cadmium-cms": "<=0.4.9",
+                "cakephp/authentication": "<3.3.6|>=4,<4.1.1",
                 "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|>=5.2.10,<5.2.12|==5.3",
                 "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
                 "cardgate/magento2": "<2.0.33",
                 "cardgate/woocommerce": "<=3.1.15",
-                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cart2quote/module-quotation": ">=4.1.6,<4.4.6|>=5,<5.4.4",
                 "cart2quote/module-quotation-encoded": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<=2.1.6",
+                "cartalyst/sentry": "<2.1.7",
                 "catfan/medoo": "<1.7.5",
                 "causal/oidc": "<4",
                 "cecil/cecil": "<7.47.1",
@@ -8990,12 +8991,13 @@
                 "coreshop/core-shop": "<4.1.9|==5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
+                "cotonti/cotonti": "<=1",
                 "couleurcitron/tarteaucitron-wp": "<0.3",
                 "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
                 "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
                 "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
-                "craftcms/cms": "<4.17.12|>=5,<5.9.18",
-                "craftcms/commerce": ">=4,<4.11|>=5,<5.6",
+                "craftcms/cms": "<4.18|>=5,<5.10",
+                "craftcms/commerce": ">=4,<=4.11.1|>=5,<=5.6.4",
                 "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
                 "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
                 "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
@@ -9050,7 +9052,7 @@
                 "drupal/commerce_alphabank_redirect": "<1.0.3",
                 "drupal/commerce_eurobank_redirect": "<2.1.1",
                 "drupal/config_split": "<1.10|>=2,<2.0.2",
-                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.5.9|>=10.6,<10.6.7|>=11,<11.2.11|>=11.3,<11.3.7",
+                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.5.10|>=10.6,<10.6.9|>=11,<11.2.12|>=11.3,<11.3.10",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
                 "drupal/currency": "<3.5",
                 "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
@@ -9123,6 +9125,7 @@
                 "fenom/fenom": "<=2.12.1",
                 "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
                 "filament/filament": ">=4,<4.3.1",
+                "filament/forms": ">=3,<=3.3.52",
                 "filament/infolists": ">=3,<3.2.115",
                 "filament/tables": ">=3,<=3.3.50|>=4,<4.8.5|>=5,<5.3.5",
                 "filegator/filegator": "<7.8",
@@ -9170,10 +9173,10 @@
                 "georgringer/news": "<10.0.4|>=11,<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
                 "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<=2.3.3",
-                "getgrav/grav": "<=2.0.0.0-RC1",
+                "getgrav/grav": "<=2.0.0.0-RC8",
                 "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
                 "getgrav/grav-plugin-form": "<9.1",
-                "getkirby/cms": "<=4.9|>=5,<=5.4",
+                "getkirby/cms": "<=4.9.3|>=5,<=5.4.3",
                 "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
@@ -9190,10 +9193,10 @@
                 "gregwar/rst": "<1.0.3",
                 "grumpydictator/firefly-iii": "<=6.6.2",
                 "gugoan/economizzer": "<=0.9.0.0-beta1",
-                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/guzzle": "<7.12.1",
                 "guzzlehttp/guzzle-services": "<1.5.4",
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
-                "guzzlehttp/psr7": "<2.10.2",
+                "guzzlehttp/psr7": "<2.12.1",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
                 "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
@@ -9248,6 +9251,7 @@
                 "jasig/phpcas": "<1.3.3",
                 "jbartels/wec-map": "<3.0.3",
                 "jcbrand/converse.js": "<3.3.3",
+                "jleehr/canto-saas-api": "<=2",
                 "joedolson/my-calendar": "<3.7.7",
                 "joelbutcher/socialstream": "<5.6|>=6,<6.2",
                 "johnbillion/query-monitor": "<3.20.4",
@@ -9291,7 +9295,7 @@
                 "lara-zeus/artemis": ">=1,<=1.0.6",
                 "lara-zeus/dynamic-dashboard": ">=3,<=3.0.1",
                 "laravel/fortify": "<1.11.1",
-                "laravel/framework": "<12.60|>=13,<13.10",
+                "laravel/framework": "<12.61.1|>=13,<13.12",
                 "laravel/laravel": ">=5.4,<5.4.22",
                 "laravel/passport": ">=13,<13.7.1",
                 "laravel/pulse": "<1.3.1",
@@ -9382,6 +9386,7 @@
                 "movim/moxl": ">=0.8,<=0.10",
                 "movingbytes/social-network": "<=1.2.1",
                 "mpdf/mpdf": "<=7.1.7",
+                "mtdowling/jmespath.php": "<2.9.1",
                 "munkireport/comment": "<4",
                 "munkireport/managedinstalls": "<2.6",
                 "munkireport/munki_facts": "<1.5",
@@ -9451,6 +9456,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
+                "paymenter/paymenter": "<1.2.11",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -9468,7 +9474,7 @@
                 "phenx/php-svg-lib": "<0.5.2",
                 "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
                 "php-mod/curl": "<2.3.2",
-                "phpbb/phpbb": "<3.3.11",
+                "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
@@ -9480,7 +9486,7 @@
                 "phpoffice/phpexcel": "<=1.8.2",
                 "phpoffice/phpspreadsheet": "<=1.30.4|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
                 "phppgadmin/phppgadmin": "<=7.13",
-                "phpseclib/phpseclib": "<=2.0.53|>=3,<=3.0.51",
+                "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
                 "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
@@ -9496,7 +9502,7 @@
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=12.3.6",
+                "pimcore/pimcore": "<=12.3.8",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
@@ -9520,8 +9526,8 @@
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
                 "processwire/processwire": "<=3.0.255",
-                "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
-                "propel/propel1": ">=1,<=1.7.1",
+                "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
+                "propel/propel1": ">=1,<1.7.2",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
                 "pterodactyl/panel": "<1.12.3",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
@@ -9584,7 +9590,7 @@
                 "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
                 "silverstripe/cms": "<4.11.3",
                 "silverstripe/comments": ">=1.3,<3.1.1",
-                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
                 "silverstripe/framework": "<5.3.23",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
@@ -9628,6 +9634,7 @@
                 "spencer14420/sp-php-email-handler": "<1",
                 "spipu/html2pdf": "<5.2.8",
                 "spiral/roadrunner": "<2025.1",
+                "spomky-labs/otphp": "<11.4.3",
                 "spoon/library": "<1.4.1",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
@@ -9701,7 +9708,9 @@
                 "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
                 "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/ux-autocomplete": "<2.36|>=3,<3.1",
+                "symfony/ux-icons": ">=2.17,<2.36.1|>=3,<3.2",
                 "symfony/ux-live-component": "<2.36|>=3,<3.1",
+                "symfony/ux-toolkit": ">=2.32,<2.36.1|>=3,<3.2",
                 "symfony/ux-twig-component": "<2.25.1",
                 "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
@@ -9803,6 +9812,9 @@
                 "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
                 "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
                 "web-feet/coastercms": "==5.5",
+                "web-token/jwt-experimental": "<=4.1.6",
+                "web-token/jwt-framework": "<=4.2.99",
+                "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
                 "web-tp3/wec_map": "<3.0.3",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
@@ -9928,7 +9940,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-12T20:48:39+00:00"
+            "time": "2026-06-22T17:34:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/routes.php
+++ b/config/routes.php
@@ -92,4 +92,12 @@ return static function (RoutingConfigurator $routes): void {
     $routes->add('send_message', '/send-message')
         ->controller(App\Controller\SendMessageController::class)
         ->methods(['GET']);
+
+    $routes->add('app_create_user', '/create-user')
+        ->controller(App\Controller\CreateUserController::class)
+        ->methods(['GET']);
+
+    $routes->add('app_create_user_with_confirmation', '/create-user-with-confirmation')
+        ->controller(App\Controller\CreateUserWithConfirmationController::class)
+        ->methods(['GET']);
 };

--- a/config/services.php
+++ b/config/services.php
@@ -26,4 +26,37 @@ return static function (ContainerConfigurator $config): void {
             'entity' => User::class,
             'lazy' => true,
         ]);
+
+    // Doctrine listeners used by App\Tests\Functional\IssuesCest to reproduce the
+    // security/request context regressions. Each is public so the tests can grab
+    // it and read the state it captured during the request.
+
+    // Issue #34 (entity-listener path).
+    $services->set(App\Doctrine\CurrentUserListener::class)
+        ->public()
+        ->tag('doctrine.orm.entity_listener', [
+            'event' => Events::prePersist,
+            'entity' => User::class,
+            'lazy' => true,
+        ]);
+
+    // Issue #34 (event-listener path).
+    $services->set(App\Doctrine\CurrentUserEventListener::class)
+        ->public();
+
+    // Issue #150 (request_stack inside a Doctrine listener).
+    $services->set(App\Doctrine\RequestStackListener::class)
+        ->public();
+
+    // Issue #151 (shared listener instance across reboots).
+    $services->set(App\Doctrine\FlushCounterListener::class)
+        ->public();
+
+    // Issue #90 (email sent from a Doctrine entity listener).
+    $services->set(App\Doctrine\SendConfirmationListener::class)
+        ->tag('doctrine.orm.entity_listener', [
+            'event' => Events::postPersist,
+            'entity' => User::class,
+            'lazy' => true,
+        ]);
 };

--- a/src/Controller/CreateUserController.php
+++ b/src/Controller/CreateUserController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Persists a user (one prePersist + one flush) so the Doctrine listeners under
+ * test fire within a real request. Shared trigger for issues #34, #150 and #151.
+ */
+final class CreateUserController extends AbstractController
+{
+    public function __invoke(EntityManagerInterface $em): Response
+    {
+        $em->persist(User::create('jane_doe@gmail.com', '123456'));
+        $em->flush();
+
+        return new Response('Created');
+    }
+}

--- a/src/Controller/CreateUserWithConfirmationController.php
+++ b/src/Controller/CreateUserWithConfirmationController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Doctrine\SendConfirmationListener;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Persists the marker user that makes App\Doctrine\SendConfirmationListener send
+ * a confirmation email from inside a Doctrine entity listener. Trigger for #90.
+ */
+final class CreateUserWithConfirmationController extends AbstractController
+{
+    public function __invoke(EntityManagerInterface $em): Response
+    {
+        $em->persist(User::create(SendConfirmationListener::TRIGGER_EMAIL, '123456'));
+        $em->flush();
+
+        return new Response('Created');
+    }
+}

--- a/src/Doctrine/CurrentUserEventListener.php
+++ b/src/Doctrine/CurrentUserEventListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Issue #34, event-listener path: a Doctrine event listener registered on the
+ * connection's event manager (not the ORM entity-listener resolver) must also
+ * see the logged-in user. This is the case the issue thread describes as a
+ * Doctrine "subscriber". Triggered by the `/create-user` route.
+ *
+ * @see https://github.com/Codeception/module-symfony/issues/34
+ */
+#[AsDoctrineListener(event: Events::prePersist)]
+final class CurrentUserEventListener
+{
+    public ?string $currentUserIdentifier = null;
+
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        if (!$args->getObject() instanceof User) {
+            return;
+        }
+
+        $this->currentUserIdentifier = $this->security->getUser()?->getUserIdentifier();
+    }
+}

--- a/src/Doctrine/CurrentUserListener.php
+++ b/src/Doctrine/CurrentUserListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Issue #34, entity-listener path: the security token must be available inside a
+ * Doctrine entity listener, exactly as it is inside a controller. Registered as a
+ * lazy `doctrine.orm.entity_listener` in config/services.php and triggered by the
+ * `/create-user` route (App\Controller\CreateUserController).
+ *
+ * @see https://github.com/Codeception/module-symfony/issues/34
+ */
+final class CurrentUserListener
+{
+    public ?string $currentUserIdentifier = null;
+
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    public function prePersist(User $user): void
+    {
+        $this->currentUserIdentifier = $this->security->getUser()?->getUserIdentifier();
+    }
+}

--- a/src/Doctrine/FlushCounterListener.php
+++ b/src/Doctrine/FlushCounterListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * Issue #151: when the EntityManager was persisted across kernel reboots, the
+ * listener instance held by Doctrine diverged from the one returned by
+ * grabService(), so state recorded during the request was invisible to the test.
+ * Both must be the same shared instance. Triggered by the `/create-user` route,
+ * which performs exactly one flush.
+ *
+ * @see https://github.com/Codeception/module-symfony/issues/151
+ */
+#[AsDoctrineListener(event: Events::onFlush)]
+final class FlushCounterListener
+{
+    public int $flushes = 0;
+
+    public function onFlush(OnFlushEventArgs $args): void
+    {
+        ++$this->flushes;
+    }
+}

--- a/src/Doctrine/RequestStackListener.php
+++ b/src/Doctrine/RequestStackListener.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Issue #150: the request_stack injected into a Doctrine listener must expose the
+ * current request (and therefore its locale and session), instead of returning
+ * null as it did when the EntityManager was persisted across kernel reboots.
+ * Triggered by the `/create-user` route.
+ *
+ * @see https://github.com/Codeception/module-symfony/issues/150
+ */
+#[AsDoctrineListener(event: Events::prePersist)]
+final class RequestStackListener
+{
+    public bool $hasRequest = false;
+    public ?string $currentLocale = null;
+
+    public function __construct(private readonly RequestStack $requestStack)
+    {
+    }
+
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        if (!$args->getObject() instanceof User) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        $this->hasRequest = $request !== null;
+        $this->currentLocale = $request?->getLocale();
+    }
+}

--- a/src/Doctrine/SendConfirmationListener.php
+++ b/src/Doctrine/SendConfirmationListener.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use App\Entity\User;
+use App\Utils\Mailer;
+
+/**
+ * Issue #90: an email sent from a Doctrine entity listener must be collected by
+ * the profiler so that seeEmailIsSent() works. Registered as a lazy
+ * `doctrine.orm.entity_listener` and triggered by the dedicated
+ * `/create-user-with-confirmation` route.
+ *
+ * @see https://github.com/Codeception/module-symfony/issues/90
+ */
+final class SendConfirmationListener
+{
+    /**
+     * Marker address: only this user triggers the mail, so the listener
+     * does not interfere with the email counts asserted in MailerCest.
+     */
+    public const TRIGGER_EMAIL = 'issue90-listener@example.com';
+
+    public function __construct(private readonly Mailer $mailer)
+    {
+    }
+
+    public function postPersist(User $user): void
+    {
+        if ($user->getEmail() === self::TRIGGER_EMAIL) {
+            $this->mailer->sendConfirmationEmail($user);
+        }
+    }
+}

--- a/tests/Functional/IssuesCest.php
+++ b/tests/Functional/IssuesCest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional;
 
+use App\Doctrine\CurrentUserEventListener;
+use App\Doctrine\CurrentUserListener;
+use App\Doctrine\FlushCounterListener;
+use App\Doctrine\RequestStackListener;
 use App\Entity\User;
 use App\Tests\Support\FunctionalTester;
 use Doctrine\DBAL\Connection;
@@ -32,6 +36,67 @@ final class IssuesCest
 
         $user = $dbalConnection->fetchOne('SELECT id FROM user WHERE email = :email', ['email' => 'fixture@fixture.test']);
         $I->assertNotFalse($user);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/34
+     */
+    public function seeLoggedInUserInsideDoctrineListener(FunctionalTester $I)
+    {
+        $user = $I->grabEntityFromRepository(User::class, ['email' => 'john_doe@gmail.com']);
+        $I->amLoggedInAs($user);
+
+        $I->amOnPage('/create-user');
+
+        $listener = $I->grabService(CurrentUserListener::class);
+        $I->assertSame('john_doe@gmail.com', $listener->currentUserIdentifier);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/34
+     */
+    public function seeLoggedInUserInsideDoctrineEventListener(FunctionalTester $I)
+    {
+        $user = $I->grabEntityFromRepository(User::class, ['email' => 'john_doe@gmail.com']);
+        $I->amLoggedInAs($user);
+
+        $I->amOnPage('/create-user');
+
+        $listener = $I->grabService(CurrentUserEventListener::class);
+        $I->assertSame('john_doe@gmail.com', $listener->currentUserIdentifier);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/150
+     */
+    public function accessRequestStackInsideDoctrineListener(FunctionalTester $I)
+    {
+        $I->amOnPage('/create-user');
+
+        $listener = $I->grabService(RequestStackListener::class);
+        $I->assertTrue($listener->hasRequest, 'request_stack has no current request inside the Doctrine listener');
+        $I->assertSame('en', $listener->currentLocale);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/151
+     */
+    public function grabSameDoctrineListenerInstanceAfterReboot(FunctionalTester $I)
+    {
+        $I->amOnPage('/create-user');
+
+        $listener = $I->grabService(FlushCounterListener::class);
+        $I->assertSame(1, $listener->flushes);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/90
+     */
+    public function seeEmailIsSentFromDoctrineListener(FunctionalTester $I)
+    {
+        $I->amOnPage('/create-user-with-confirmation');
+
+        $I->seeEmailIsSent();
     }
 
     /**


### PR DESCRIPTION
Companion test PR for the module fix **codeception/module-symfony#236** (security/request context missing inside Doctrine listeners after a kernel reboot). Targets the Symfony `8.1` branch.

Adds functional regression tests in `IssuesCest` plus the fixtures they exercise (Doctrine listeners, controllers, routes/services wiring):

- codeception/module-symfony#34 — logged-in user is visible inside a Doctrine listener, via both the entity-listener and the event-listener (event-manager) paths
- codeception/module-symfony#150 — `request_stack` exposes the current request (and locale) inside a Doctrine listener
- codeception/module-symfony#151 — the listener instance returned by `grabService()` is the same one Doctrine used (shared services survive reboots)
- codeception/module-symfony#90 — an email sent from a Doctrine listener is collected by the profiler, so `seeEmailIsSent()` works

Each test fails against the current released module and passes with codeception/module-symfony#236. Per the two-PR contribution process, this should land together with that module change.
