### PR TITLE
Add functional tests for inherited Symfony assertions (7.4)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5886,12 +5886,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387"
+                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/6cd215032d717b290a80e45037fe6cac54ec6387",
-                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
+                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
                 "shasum": ""
             },
             "require": {
@@ -5984,7 +5984,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-22T17:15:57+00:00"
+            "time": "2026-06-23T20:14:24+00:00"
         },
         {
             "name": "codeception/stub",
@@ -7097,16 +7097,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.1",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
@@ -7115,7 +7115,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -7196,7 +7196,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -7212,20 +7212,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T09:49:37+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "masterminds/html5",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
                 "shasum": ""
             },
             "require": {
@@ -7233,7 +7233,7 @@
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
             },
             "type": "library",
             "extra": {
@@ -7277,9 +7277,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
             },
-            "time": "2025-07-25T09:04:22+00:00"
+            "time": "2026-06-23T18:43:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -9005,12 +9005,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a"
+                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/55f7461997e52f12c93d307ccdcb0ee8e89f336a",
-                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/23afac1b181cebf9a272d9cb3423c6c39f3710d9",
+                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9",
                 "shasum": ""
             },
             "conflict": {
@@ -9621,7 +9621,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
-                "paymenter/paymenter": "<1.2.11",
+                "paymenter/paymenter": "<1.5",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -10105,7 +10105,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-22T17:34:25+00:00"
+            "time": "2026-06-22T21:03:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/tests/Functional/BrowserCest.php
+++ b/tests/Functional/BrowserCest.php
@@ -21,6 +21,26 @@ final class BrowserCest
         $I->assertBrowserHasCookie('TESTCOOKIE');
     }
 
+    public function assertBrowserHistoryIsNotOnFirstPage(FunctionalTester $I)
+    {
+        $I->amOnPage('/');
+        $I->amOnPage('/login');
+        $I->assertBrowserHistoryIsNotOnFirstPage();
+    }
+
+    public function assertBrowserHistoryIsOnFirstPage(FunctionalTester $I)
+    {
+        $I->amOnPage('/');
+        $I->assertBrowserHistoryIsOnFirstPage();
+    }
+
+    public function assertBrowserHistoryIsOnLastPage(FunctionalTester $I)
+    {
+        $I->amOnPage('/');
+        $I->amOnPage('/login');
+        $I->assertBrowserHistoryIsOnLastPage();
+    }
+
     public function assertBrowserNotHasCookie(FunctionalTester $I)
     {
         $I->setCookie('TESTCOOKIE', 'codecept');

--- a/tests/Functional/DomCrawlerCest.php
+++ b/tests/Functional/DomCrawlerCest.php
@@ -13,6 +13,21 @@ final class DomCrawlerCest
         $I->amOnPage('/test_page');
     }
 
+    public function assertAnySelectorTextContains(FunctionalTester $I): void
+    {
+        $I->assertAnySelectorTextContains('label', 'Example Input', 'A label should contain "Example Input".');
+    }
+
+    public function assertAnySelectorTextNotContains(FunctionalTester $I): void
+    {
+        $I->assertAnySelectorTextNotContains('label', 'Nonexistent label text', 'No label should contain this text.');
+    }
+
+    public function assertAnySelectorTextSame(FunctionalTester $I): void
+    {
+        $I->assertAnySelectorTextSame('label', 'Username', 'A label should be exactly "Username".');
+    }
+
     public function assertCheckboxChecked(FunctionalTester $I): void
     {
         $I->assertCheckboxChecked('exampleCheckbox', 'The checkbox should be checked.');
@@ -36,6 +51,11 @@ final class DomCrawlerCest
     public function assertPageTitleSame(FunctionalTester $I): void
     {
         $I->assertPageTitleSame('Test Page', 'The page title should be "Test Page".');
+    }
+
+    public function assertSelectorCount(FunctionalTester $I): void
+    {
+        $I->assertSelectorCount(3, 'input', 'The test page should contain exactly 3 inputs.');
     }
 
     public function assertSelectorExists(FunctionalTester $I): void

--- a/tests/Functional/MailerCest.php
+++ b/tests/Functional/MailerCest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Tests\Support\FunctionalTester;
+use Symfony\Component\Mime\Email;
 
 final class MailerCest
 {
@@ -13,6 +14,26 @@ final class MailerCest
         $I->registerUser('john_doe@gmail.com', '123456', followRedirects: false);
         // There is already an account with this email
         $I->dontSeeEmailIsSent();
+    }
+
+    public function getMailerEvents(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $I->assertNotEmpty($I->getMailerEvents());
+    }
+
+    public function getMailerMessage(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $I->assertInstanceOf(Email::class, $I->getMailerMessage());
+    }
+
+    public function getMailerMessages(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $messages = $I->getMailerMessages();
+        $I->assertNotEmpty($messages);
+        $I->assertInstanceOf(Email::class, $messages[0]);
     }
 
     public function grabLastSentEmail(FunctionalTester $I)

--- a/tests/Functional/MimeCest.php
+++ b/tests/Functional/MimeCest.php
@@ -19,6 +19,11 @@ final class MimeCest
         $I->assertEmailAddressContains('To', 'jane_doe@example.com');
     }
 
+    public function assertEmailAddressNotContains(FunctionalTester $I)
+    {
+        $I->assertEmailAddressNotContains('To', 'john_doe@example.com');
+    }
+
     public function assertEmailAttachmentCount(FunctionalTester $I)
     {
         $I->assertEmailAttachmentCount(1);
@@ -52,6 +57,16 @@ final class MimeCest
     public function assertEmailNotHasHeader(FunctionalTester $I)
     {
         $I->assertEmailNotHasHeader('Bcc');
+    }
+
+    public function assertEmailSubjectContains(FunctionalTester $I)
+    {
+        $I->assertEmailSubjectContains('Account created successfully');
+    }
+
+    public function assertEmailSubjectNotContains(FunctionalTester $I)
+    {
+        $I->assertEmailSubjectNotContains('Password reset');
     }
 
     public function assertEmailTextBodyContains(FunctionalTester $I)


### PR DESCRIPTION
## What

Functional tests for the inherited Symfony assertions added in [Codeception/module-symfony#240](https://github.com/Codeception/module-symfony/pull/240).

### Added tests

- **BrowserCest**: `assertBrowserHistoryIsOnFirstPage`, `assertBrowserHistoryIsNotOnFirstPage`, `assertBrowserHistoryIsOnLastPage`
- **DomCrawlerCest**: `assertSelectorCount`, `assertAnySelectorTextContains`, `assertAnySelectorTextSame`, `assertAnySelectorTextNotContains`
- **MailerCest**: `getMailerEvents`, `getMailerMessages`, `getMailerMessage`
- **MimeCest**: `assertEmailAddressNotContains`, `assertEmailSubjectContains`, `assertEmailSubjectNotContains`

All new methods are placed in alphabetical order, reuse the existing fixtures (`/test_page`, `/send-email`, `registerUser()`), and pass locally against module-symfony#240.

`composer.lock` refreshed.

## Notes

- `assertBrowserHistoryIsNotOnLastPage` is intentionally **not** covered here: reaching a "not on last page" state requires a raw `client->back()` (which keeps forward history), but the Codeception actor API only exposes `moveBack()`, which re-dispatches and truncates forward history — so the state is unreachable via functional steps. It is covered by the unit test in module-symfony#240.
- The browser-history assertions require `symfony/browser-kit` ≥ 7.4, so they are included only on the 7.4 (and 8.1) branches.
