### PR TITLE
Add functional tests for inherited Symfony assertions (5.4)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5946,12 +5946,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387"
+                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/6cd215032d717b290a80e45037fe6cac54ec6387",
-                "reference": "6cd215032d717b290a80e45037fe6cac54ec6387",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
+                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
                 "shasum": ""
             },
             "require": {
@@ -6044,7 +6044,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-22T17:15:57+00:00"
+            "time": "2026-06-23T20:14:24+00:00"
         },
         {
             "name": "codeception/stub",
@@ -7157,26 +7157,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.1",
+            "version": "7.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
+                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
-                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
+                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.1",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -7265,7 +7265,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.3"
             },
             "funding": [
                 {
@@ -7281,7 +7281,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T14:12:49+00:00"
+            "time": "2026-06-23T15:29:02+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -7369,16 +7369,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.1",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
@@ -7387,7 +7387,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -7468,7 +7468,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -7484,7 +7484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T09:49:37+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -9215,12 +9215,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a"
+                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/55f7461997e52f12c93d307ccdcb0ee8e89f336a",
-                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/23afac1b181cebf9a272d9cb3423c6c39f3710d9",
+                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9",
                 "shasum": ""
             },
             "conflict": {
@@ -9831,7 +9831,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
-                "paymenter/paymenter": "<1.2.11",
+                "paymenter/paymenter": "<1.5",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -10315,7 +10315,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-22T17:34:25+00:00"
+            "time": "2026-06-22T21:03:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/tests/Functional/MailerCest.php
+++ b/tests/Functional/MailerCest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Tests\Support\FunctionalTester;
+use Symfony\Component\Mime\Email;
 
 final class MailerCest
 {
@@ -13,6 +14,26 @@ final class MailerCest
         $I->registerUser('john_doe@gmail.com', '123456', followRedirects: false);
         // There is already an account with this email
         $I->dontSeeEmailIsSent();
+    }
+
+    public function getMailerEvents(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $I->assertNotEmpty($I->getMailerEvents());
+    }
+
+    public function getMailerMessage(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $I->assertInstanceOf(Email::class, $I->getMailerMessage());
+    }
+
+    public function getMailerMessages(FunctionalTester $I)
+    {
+        $I->registerUser('jane_doe@gmail.com', '123456', followRedirects: false);
+        $messages = $I->getMailerMessages();
+        $I->assertNotEmpty($messages);
+        $I->assertInstanceOf(Email::class, $messages[0]);
     }
 
     public function grabLastSentEmail(FunctionalTester $I)

--- a/tests/Functional/MimeCest.php
+++ b/tests/Functional/MimeCest.php
@@ -19,6 +19,11 @@ final class MimeCest
         $I->assertEmailAddressContains('To', 'jane_doe@example.com');
     }
 
+    public function assertEmailAddressNotContains(FunctionalTester $I)
+    {
+        $I->assertEmailAddressNotContains('To', 'john_doe@example.com');
+    }
+
     public function assertEmailAttachmentCount(FunctionalTester $I)
     {
         $I->assertEmailAttachmentCount(1);


### PR DESCRIPTION
## What

Functional tests for the inherited Symfony assertions added in [Codeception/module-symfony#240](https://github.com/Codeception/module-symfony/pull/240), limited to the methods whose underlying constraints exist on Symfony 5.4.

### Added tests

- **MailerCest**: `getMailerEvents`, `getMailerMessages`, `getMailerMessage`
- **MimeCest**: `assertEmailAddressNotContains`

New methods are placed in alphabetical order, reuse the existing fixtures (`/send-email`, `registerUser()`), and pass locally against module-symfony#240.

`composer.lock` refreshed.

## Notes

The remaining assertions are **omitted on 5.4** because their underlying Symfony constraints were introduced later (verified absent on 5.4):

- `assertSelectorCount`, `assertAnySelectorText*` → `symfony/dom-crawler` 6.4
- `assertEmailSubjectContains` / `assertEmailSubjectNotContains` → `symfony/mime` 6.2
- `assertBrowserHistoryIs*` → `symfony/browser-kit` 7.4

These are covered in the 6.4 / 7.4 / 8.1 companion PRs.
