### PR TITLE
[5.4] Add functional test for issue #130 (DI state across kernel reboots)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6245,12 +6245,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5"
+                "reference": "bb77041e9b3f3adfb1b215b55b680297baf56b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7f0cd5d5ef89658ed1a56185bf33047477686fc5",
-                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/bb77041e9b3f3adfb1b215b55b680297baf56b51",
+                "reference": "bb77041e9b3f3adfb1b215b55b680297baf56b51",
                 "shasum": ""
             },
             "require": {
@@ -6344,7 +6344,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-25T19:43:59+00:00"
+            "time": "2026-06-25T22:17:23+00:00"
         },
         {
             "name": "codeception/stub",
@@ -7290,16 +7290,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.10",
+            "version": "v3.95.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17"
+                "reference": "35f98e1293283397824d7f349ce5afb8747c3cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/93e1ab3e1f153024bd3ab23c8a349556063c6f17",
-                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/35f98e1293283397824d7f349ce5afb8747c3cd5",
+                "reference": "35f98e1293283397824d7f349ce5afb8747c3cd5",
                 "shasum": ""
             },
             "require": {
@@ -7333,7 +7333,7 @@
             "require-dev": {
                 "facile-it/paraunit": "^1.3.1 || ^2.11.0",
                 "infection/infection": "^0.32.7",
-                "justinrainbow/json-schema": "^6.9.0",
+                "justinrainbow/json-schema": "^6.10.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
@@ -7383,7 +7383,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.10"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.11"
             },
             "funding": [
                 {
@@ -7391,7 +7391,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-19T14:45:22+00:00"
+            "time": "2026-06-25T14:17:04+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -9515,12 +9515,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9"
+                "reference": "c5afdab923ee443a1aadcdd52543132e5d92db90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/23afac1b181cebf9a272d9cb3423c6c39f3710d9",
-                "reference": "23afac1b181cebf9a272d9cb3423c6c39f3710d9",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c5afdab923ee443a1aadcdd52543132e5d92db90",
+                "reference": "c5afdab923ee443a1aadcdd52543132e5d92db90",
                 "shasum": ""
             },
             "conflict": {
@@ -9654,7 +9654,7 @@
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
                 "composer/composer": "<2.2.28|>=2.3,<2.9.8",
-                "concrete5/concrete5": "<9.4.8",
+                "concrete5/concrete5": "<9.5.1",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
@@ -9799,10 +9799,10 @@
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
                 "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
-                "filament/filament": ">=4,<4.3.1",
+                "filament/filament": ">=3,<=3.3.51|>=4,<4.11.5|>=5,<5.6.5",
                 "filament/forms": ">=3,<=3.3.52",
-                "filament/infolists": ">=3,<3.2.115",
-                "filament/tables": ">=3,<=3.3.50|>=4,<4.8.5|>=5,<5.3.5",
+                "filament/infolists": ">=3,<3.2.115|>=4,<=4.11.4|>=5,<=5.6.4",
+                "filament/tables": ">=3,<=3.3.50|>=4,<=4.11.4|>=5,<=5.6.4",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -10155,7 +10155,7 @@
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<5.2.2",
-                "phpmyfaq/phpmyfaq": "<4.1.3",
+                "phpmyfaq/phpmyfaq": "<4.1.4",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
@@ -10263,10 +10263,10 @@
                 "silverstripe-australia/advancedreports": ">=1,<=2",
                 "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
                 "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
-                "silverstripe/cms": "<4.11.3",
+                "silverstripe/cms": "<6.2.1",
                 "silverstripe/comments": ">=1.3,<3.1.1",
                 "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
-                "silverstripe/framework": "<5.3.23",
+                "silverstripe/framework": "<6.2.2",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/recipe-cms": ">=4.5,<4.5.3",
@@ -10276,7 +10276,8 @@
                 "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
                 "silverstripe/subsites": ">=2,<2.6.1",
                 "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
-                "silverstripe/userforms": "<3|>=5,<5.4.2",
+                "silverstripe/userforms": "<6.4.9|>=7,<7.0.7|>=7.1,<7.1.1",
+                "silverstripe/versioned": "<3.2.1",
                 "silverstripe/versioned-admin": ">=1,<1.11.1",
                 "simogeo/filemanager": "<=2.5",
                 "simple-updates/phpwhois": "<=1",
@@ -10295,10 +10296,10 @@
                 "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
                 "sjbr/static-info-tables": "<2.3.1",
                 "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
-                "slim/slim": "<2.6",
+                "slim/slim": "<2.6|>=4.4,<=4.15.1",
                 "slub/slub-events": "<3.0.3",
                 "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<8.4.1",
+                "snipe/snipe-it": "<=8.6.1",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
@@ -10338,6 +10339,7 @@
                 "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
                 "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<=2.0.15|>=2.1,<=2.1.11|>=2.2,<=2.2.2",
+                "symbiote/silverstripe-advancedworkflow": "<6.4.5|>=7,<7.1.3|>=7.2,<7.2.1",
                 "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
                 "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
                 "symbiote/silverstripe-seed": "<6.0.3",
@@ -10405,7 +10407,7 @@
                 "thelia/thelia": ">=2.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.1.3",
+                "thorsten/phpmyfaq": "<4.1.4",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
@@ -10615,7 +10617,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-22T21:03:44+00:00"
+            "time": "2026-06-25T18:49:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/routes.php
+++ b/config/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Controller\BrowserController;
 use App\Controller\DashboardController;
 use App\Controller\DomCrawlerController;
+use App\Controller\ExternalApiController;
 use App\Controller\FormController;
 use App\Controller\HomeController;
 use App\Controller\HttpClientController;
@@ -15,6 +16,10 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 return static function (RoutingConfigurator $routes): void {
     $routes->add('index', '/')
         ->controller(HomeController::class)
+        ->methods(['GET']);
+
+    $routes->add('app_external_api', '/external-api')
+        ->controller(ExternalApiController::class)
         ->methods(['GET']);
 
     $routes->add('app_login', '/login')

--- a/config/services.php
+++ b/config/services.php
@@ -59,4 +59,7 @@ return static function (ContainerConfigurator $config): void {
             'entity' => User::class,
             'lazy' => true,
         ]);
+
+    $services->set(App\Service\ExternalApiStub::class)
+        ->public();
 };

--- a/src/Controller/ExternalApiController.php
+++ b/src/Controller/ExternalApiController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ExternalApiStub;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ExternalApiController extends AbstractController
+{
+    public function __construct(
+        private readonly ExternalApiStub $externalApi,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        return new Response($this->externalApi->getResponse());
+    }
+}

--- a/src/Service/ExternalApiStub.php
+++ b/src/Service/ExternalApiStub.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * A stand-in for an external API client whose response can be faked at runtime.
+ */
+final class ExternalApiStub
+{
+    public const REAL_RESPONSE = 'Real API response';
+
+    private string $response = self::REAL_RESPONSE;
+
+    public function setFakeResponse(string $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): string
+    {
+        return $this->response;
+    }
+}

--- a/tests/Functional/IssuesCest.php
+++ b/tests/Functional/IssuesCest.php
@@ -9,6 +9,7 @@ use App\Doctrine\CurrentUserListener;
 use App\Doctrine\FlushCounterListener;
 use App\Doctrine\RequestStackListener;
 use App\Entity\User;
+use App\Service\ExternalApiStub;
 use App\Tests\Support\FunctionalTester;
 use Doctrine\DBAL\Connection;
 
@@ -117,5 +118,22 @@ final class IssuesCest
         $I->assertIsEmpty($output);
         $numRecords = $I->grabNumRecords(User::class);
         $I->assertSame(1, $numRecords);
+    }
+
+    /**
+     * @see https://github.com/Codeception/module-symfony/issues/130
+     */
+    public function keepConfiguredServiceStateAcrossKernelReboot(FunctionalTester $I)
+    {
+        $I->amOnPage('/external-api');
+        $I->see(ExternalApiStub::REAL_RESPONSE);
+
+        /** @var ExternalApiStub $externalApi */
+        $externalApi = $I->grabService(ExternalApiStub::class);
+        $externalApi->setFakeResponse('Faked API response');
+        $I->persistService(ExternalApiStub::class);
+
+        $I->amOnPage('/external-api');
+        $I->see('Faked API response');
     }
 }


### PR DESCRIPTION
Companion test for [Codeception/module-symfony#130](https://github.com/Codeception/module-symfony/issues/130).

### Background

The issue proposed rebooting the kernel **right after** each request (instead of lazily, at the start of the next request). That change would actually diverge from pure Symfony: `Symfony\Bundle\FrameworkBundle\KernelBrowser::doRequest()` reboots lazily *before* the next request, precisely so the request-handling kernel stays alive for post-request inspection. Rebooting right after a request would destroy that state and break a large number of `see*`/`grab*` assertions (session, security token, live services…).

The real need behind the issue — *configure a service on the fly and have the next request use it* — is already supported in a Symfony-coherent way, **without** changing the reboot timing:

- `persistService()` / `persistPermanentService()` — the configured instance is re-injected into the freshly booted container on the next reboot (isolation is preserved for everything else).
- `rebootable_client: false` (= Symfony's `disableReboot()`) + `rebootClientKernel()` for manual isolation.

### What this PR adds

A regression test under `IssuesCest` that mirrors the issue's exact scenario and proves it is resolved with the **default** rebootable client:

1. Request `/external-api` → sees the real response.
2. Grab the `ExternalApiStub` service, fake its response, `persistService(...)`.
3. Request `/external-api` again (kernel reboots) → still sees the **faked** response.

Supporting fixtures: an `ExternalApiStub` service (public, fakeable), plus a controller + route that echo its state.

No change to `codeception/module-symfony` is required — this documents and guards the already-correct behaviour.