### PR TITLE
Add Messenger functional tests

### DIFF
--- a/.env
+++ b/.env
@@ -18,3 +18,10 @@ MAILER_DSN=null://null
 ###> symfony/notifier ###
 NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/framework-bundle": "8.0.*",
         "symfony/http-client": "8.0.*",
         "symfony/mailer": "8.0.*",
+        "symfony/messenger": "8.0.*",
         "symfony/notifier": "8.0.*",
         "symfony/runtime": "8.0.*",
         "symfony/security-bundle": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97071fb3ca79fa8635d48d6a5c899572",
+    "content-hash": "e0eacb6f6d4ced605ab11f2ae1045ea7",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -2822,6 +2822,96 @@
                 }
             ],
             "time": "2026-05-20T07:22:03+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v8.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "ec7ad0b1eb8ad19de1a99d4d051311fa99879d74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/ec7ad0b1eb8ad19de1a99d4d051311fa99879d74",
+                "reference": "ec7ad0b1eb8ad19de1a99d4d051311fa99879d74",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/log": "^1|^2|^3",
+                "symfony/clock": "^7.4|^8.0"
+            },
+            "conflict": {
+                "symfony/console": "<7.4",
+                "symfony/event-dispatcher-contracts": "<2.5",
+                "symfony/lock": "<7.4",
+                "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4.4|^8.0.4",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps applications send and receive messages to/from other applications or via message queues",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/messenger/tree/v8.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-19T19:56:11+00:00"
         },
         {
             "name": "symfony/mime",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,11 @@
+framework:
+    mailer:
+        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
+        # emails through the bus, which would double-count messages in MailerCest.
+        message_bus: false
+    messenger:
+        # A single synchronous bus; messages without explicit routing are handled in-process,
+        # which is what the Messenger assertions verify.
+        default_bus: messenger.bus.default
+        buses:
+            messenger.bus.default: ~

--- a/config/routes.php
+++ b/config/routes.php
@@ -92,4 +92,8 @@ return static function (RoutingConfigurator $routes): void {
     $routes->add('send_message', '/send-message')
         ->controller(App\Controller\SendMessageController::class)
         ->methods(['GET']);
+
+    $routes->add('dispatch_message', '/dispatch-message')
+        ->controller(App\Controller\DispatchMessageController::class)
+        ->methods(['GET']);
 };

--- a/src/Controller/DispatchMessageController.php
+++ b/src/Controller/DispatchMessageController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchMessageController extends AbstractController
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $this->bus->dispatch(new SendWelcomeMessage('jane_doe@example.com'));
+
+        return $this->json(['message' => 'Message dispatched']);
+    }
+}

--- a/src/Message/SendWelcomeMessage.php
+++ b/src/Message/SendWelcomeMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final class SendWelcomeMessage
+{
+    public function __construct(
+        private readonly string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SendWelcomeMessageHandler
+{
+    public function __invoke(SendWelcomeMessage $message): void
+    {
+        // No-op: the dispatch itself is what the assertions verify.
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -175,6 +175,18 @@
             "./config/packages/mailer.yaml"
         ]
     },
+    "symfony/messenger": {
+        "version": "8.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "d8936e2e2230637ef97e5eecc0eea074eecae58b"
+        },
+        "files": [
+            "./config/packages/messenger.yaml"
+        ]
+    },
     "symfony/notifier": {
         "version": "7.3",
         "recipe": {

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Message\SendWelcomeMessage;
+use App\Tests\Support\FunctionalTester;
+use stdClass;
+
+final class MessengerCest
+{
+    public function assertMessageCount(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->assertMessageCount(1);
+        $I->assertMessageCount(1, 'messenger.bus.default');
+    }
+
+    public function seeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->seeMessageDispatched(SendWelcomeMessage::class);
+        $I->seeMessageDispatched(SendWelcomeMessage::class, 'messenger.bus.default');
+    }
+
+    public function dontSeeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->dontSeeMessageDispatched(stdClass::class);
+    }
+
+    public function grabDispatchedMessageClasses(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $messages = $I->grabDispatchedMessageClasses();
+        $I->assertSame([SendWelcomeMessage::class], $messages);
+    }
+
+    public function noMessagesDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/');
+        $I->assertMessageCount(0);
+        $I->assertSame([], $I->grabDispatchedMessageClasses());
+    }
+}


### PR DESCRIPTION
Companion to **Codeception/module-symfony#241** (adds `MessengerAssertionsTrait`).

## What

Adds `tests/Functional/MessengerCest.php` exercising the new Messenger steps end-to-end:

- `assertMessageCount(int, ?bus)`
- `seeMessageDispatched(class, ?bus)` / `dontSeeMessageDispatched(class, ?bus)`
- `grabDispatchedMessageClasses(?bus)`

## App changes

- Adds `symfony/messenger` and enables it with a single synchronous default bus (`messenger.bus.default`).
- Adds a sample `SendWelcomeMessage`, its handler, and a `/dispatch-message` controller/route the Cest hits.
- Sets `mailer.message_bus: false` so enabling Messenger does not route Mailer through the bus (which would otherwise double-count messages and break `MailerCest`).

Same change as the 7.4 PR (#53); validated there with `MessengerCest` 5/5 and `MailerCest`/`NotifierCest` green.