### PR TITLE
Add Messenger functional tests (6.4)

### DIFF
--- a/.env
+++ b/.env
@@ -20,8 +20,5 @@ NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
 
 ###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###

--- a/.env
+++ b/.env
@@ -18,3 +18,10 @@ MAILER_DSN=null://null
 ###> symfony/notifier ###
 NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/framework-bundle": "6.4.*",
         "symfony/http-client": "6.4.*",
         "symfony/mailer": "6.4.*",
+        "symfony/messenger": "6.4.*",
         "symfony/notifier": "6.4.*",
         "symfony/runtime": "6.4.*",
         "symfony/security-bundle": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -5858,12 +5858,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da"
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7f0cd5d5ef89658ed1a56185bf33047477686fc5",
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5",
                 "shasum": ""
             },
             "require": {
@@ -5897,6 +5897,7 @@
                 "symfony/http-foundation": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/http-kernel": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mailer": "^5.4 | ^6.4 | ^7.4 | ^8.0",
+                "symfony/messenger": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mime": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/notifier": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/options-resolver": "^5.4 | ^6.4 | ^7.4 | ^8.0",
@@ -5956,7 +5957,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-23T20:14:24+00:00"
+            "time": "2026-06-25T19:43:59+00:00"
         },
         {
             "name": "codeception/stub",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e84b3f7c947ef48bc1d9147b70250f71",
+    "content-hash": "0c0be7d834ce65fc3ed081c5bb5ec7a0",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -2893,6 +2893,97 @@
                 }
             ],
             "time": "2026-05-19T20:33:22+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v6.4.39",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "c96b8feaeedd0b19a104e08e953e6068a35ce553"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/c96b8feaeedd0b19a104e08e953e6068a35ce553",
+                "reference": "c96b8feaeedd0b19a104e08e953e6068a35ce553",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/clock": "^6.3|^7.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/console": "<6.3",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/event-dispatcher-contracts": "<2.5",
+                "symfony/framework-bundle": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/serializer": "<5.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/console": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps applications send and receive messages to/from other applications or via message queues",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/messenger/tree/v6.4.39"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T12:57:53+00:00"
         },
         {
             "name": "symfony/mime",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,11 @@
+framework:
+    mailer:
+        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
+        # emails through the bus, which would double-count messages in MailerCest.
+        message_bus: false
+    messenger:
+        # A single synchronous bus; messages without explicit routing are handled in-process,
+        # which is what the Messenger assertions verify.
+        default_bus: messenger.bus.default
+        buses:
+            messenger.bus.default: ~

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,11 +1,7 @@
 framework:
     mailer:
-        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
-        # emails through the bus, which would double-count messages in MailerCest.
         message_bus: false
     messenger:
-        # A single synchronous bus; messages without explicit routing are handled in-process,
-        # which is what the Messenger assertions verify.
         default_bus: messenger.bus.default
         buses:
             messenger.bus.default: ~

--- a/config/routes.php
+++ b/config/routes.php
@@ -100,4 +100,8 @@ return static function (RoutingConfigurator $routes): void {
     $routes->add('app_create_user_with_confirmation', '/create-user-with-confirmation')
         ->controller(App\Controller\CreateUserWithConfirmationController::class)
         ->methods(['GET']);
+
+    $routes->add('dispatch_message', '/dispatch-message')
+        ->controller(App\Controller\DispatchMessageController::class)
+        ->methods(['GET']);
 };

--- a/src/Controller/DispatchMessageController.php
+++ b/src/Controller/DispatchMessageController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchMessageController extends AbstractController
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $this->bus->dispatch(new SendWelcomeMessage('jane_doe@example.com'));
+
+        return $this->json(['message' => 'Message dispatched']);
+    }
+}

--- a/src/Message/SendWelcomeMessage.php
+++ b/src/Message/SendWelcomeMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final class SendWelcomeMessage
+{
+    public function __construct(
+        private readonly string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SendWelcomeMessageHandler
+{
+    public function __invoke(SendWelcomeMessage $message): void
+    {
+        // No-op: the dispatch itself is what the assertions verify.
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -12,6 +12,5 @@ final class SendWelcomeMessageHandler
 {
     public function __invoke(SendWelcomeMessage $message): void
     {
-        // No-op: the dispatch itself is what the assertions verify.
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -172,6 +172,18 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/messenger": {
+        "version": "6.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "d8936e2e2230637ef97e5eecc0eea074eecae58b"
+        },
+        "files": [
+            "./config/packages/messenger.yaml"
+        ]
+    },
     "symfony/notifier": {
         "version": "6.4",
         "recipe": {

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Message\SendWelcomeMessage;
+use App\Tests\Support\FunctionalTester;
+use stdClass;
+
+final class MessengerCest
+{
+    public function assertMessageCount(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->assertMessageCount(1);
+        $I->assertMessageCount(1, 'messenger.bus.default');
+    }
+
+    public function seeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->seeMessageDispatched(SendWelcomeMessage::class);
+        $I->seeMessageDispatched(SendWelcomeMessage::class, 'messenger.bus.default');
+    }
+
+    public function dontSeeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->dontSeeMessageDispatched(stdClass::class);
+    }
+
+    public function grabDispatchedMessageClasses(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $messages = $I->grabDispatchedMessageClasses();
+        $I->assertSame([SendWelcomeMessage::class], $messages);
+    }
+
+    public function noMessagesDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/');
+        $I->assertMessageCount(0);
+        $I->assertSame([], $I->grabDispatchedMessageClasses());
+    }
+}

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -10,11 +10,11 @@ use stdClass;
 
 final class MessengerCest
 {
-    public function assertMessageCount(FunctionalTester $I): void
+    public function seeDispatchedMessageCount(FunctionalTester $I): void
     {
         $I->amOnPage('/dispatch-message');
-        $I->assertMessageCount(1);
-        $I->assertMessageCount(1, 'messenger.bus.default');
+        $I->seeDispatchedMessageCount(1);
+        $I->seeDispatchedMessageCount(1, 'messenger.bus.default');
     }
 
     public function seeMessageDispatched(FunctionalTester $I): void
@@ -40,7 +40,7 @@ final class MessengerCest
     public function noMessagesDispatched(FunctionalTester $I): void
     {
         $I->amOnPage('/');
-        $I->assertMessageCount(0);
+        $I->seeDispatchedMessageCount(0);
         $I->assertSame([], $I->grabDispatchedMessageClasses());
     }
 }


### PR DESCRIPTION
Companion to **Codeception/module-symfony#241** (adds `MessengerAssertionsTrait`).

## What

Adds `tests/Functional/MessengerCest.php` exercising the new Messenger steps end-to-end:

- `seeDispatchedMessageCount(int, ?bus)`
- `seeMessageDispatched(class, ?bus)` / `dontSeeMessageDispatched(class, ?bus)`
- `grabDispatchedMessageClasses(?bus)`

## App changes

- Adds `symfony/messenger` and enables it with a single synchronous default bus (`messenger.bus.default`).
- Adds a sample `SendWelcomeMessage`, its handler, and a `/dispatch-message` controller/route the Cest hits.
- Sets `mailer.message_bus: false` so enabling Messenger does not route Mailer through the bus (which would otherwise double-count messages and break `MailerCest`).

Same change as the 7.4 PR (#53); validated there with `MessengerCest` 5/5 and `MailerCest`/`NotifierCest` green.

## CI is red until the module PR merges
These steps live in `codeception/module-symfony` (PR #241), which is not yet released. The app installs the module via `dev-main`, so `FunctionalTester` does not expose `seeDispatchedMessageCount` / `seeMessageDispatched` / `dontSeeMessageDispatched` / `grabDispatchedMessageClasses` yet — the `Call to undefined method ...` failures are expected pre-merge. Once #241 is merged to `main`, refreshing the lock (`composer update codeception/module-symfony`) makes this branch green.
