### PR TITLE
Add Messenger functional tests (5.4)

### DIFF
--- a/.env
+++ b/.env
@@ -20,8 +20,5 @@ NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
 
 ###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###

--- a/.env
+++ b/.env
@@ -18,3 +18,10 @@ MAILER_DSN=null://null
 ###> symfony/notifier ###
 NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/framework-bundle": "5.4.*",
         "symfony/http-client": "5.4.*",
         "symfony/mailer": "5.4.*",
+        "symfony/messenger": "5.4.*",
         "symfony/notifier": "5.4.*",
         "symfony/runtime": "5.4.*",
         "symfony/security-bundle": "5.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bcfea69e11f77197fcef933eff85359",
+    "content-hash": "e2d69a906a460aff81f7a180b79486ae",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -959,6 +959,75 @@
             "time": "2021-07-14T16:41:46+00:00"
         },
         {
+            "name": "symfony/amqp-messenger",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/amqp-messenger.git",
+                "reference": "822ad5f425ef362580273a175c45aa765220fe73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/amqp-messenger/zipball/822ad5f425ef362580273a175c45aa765220fe73",
+                "reference": "822ad5f425ef362580273a175c45aa765220fe73",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/messenger": "^5.3|^6.0"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/property-access": "^4.4|^5.0|^6.0",
+                "symfony/serializer": "^4.4|^5.0|^6.0"
+            },
+            "type": "symfony-messenger-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\Bridge\\Amqp\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony AMQP extension Messenger Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/amqp-messenger/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
             "name": "symfony/apache-pack",
             "version": "v1.0.1",
             "source": {
@@ -1617,6 +1686,79 @@
                 }
             ],
             "time": "2024-11-20T10:49:45+00:00"
+        },
+        {
+            "name": "symfony/doctrine-messenger",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/doctrine-messenger.git",
+                "reference": "3f5a6e1876fbf57e836ba0a02eb0a636e08c0d96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/3f5a6e1876fbf57e836ba0a02eb0a636e08c0d96",
+                "reference": "3f5a6e1876fbf57e836ba0a02eb0a636e08c0d96",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/messenger": "^5.1|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.13|^3|^4",
+                "doctrine/persistence": "^1.3|^2|^3",
+                "symfony/property-access": "^4.4|^5.0|^6.0",
+                "symfony/serializer": "^4.4|^5.0|^6.0"
+            },
+            "type": "symfony-messenger-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\Bridge\\Doctrine\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Doctrine Messenger Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/doctrine-messenger/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -2832,6 +2974,96 @@
             "time": "2026-05-11T06:39:31+00:00"
         },
         {
+            "name": "symfony/messenger",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "c21d463ba813a3fe9833f46114310fac99bd66e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/c21d463ba813a3fe9833f46114310fac99bd66e0",
+                "reference": "c21d463ba813a3fe9833f46114310fac99bd66e0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1|^2|^3",
+                "symfony/amqp-messenger": "^5.1|^6.0",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/doctrine-messenger": "^5.1|^6.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/redis-messenger": "^5.1|^6.0"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/framework-bundle": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/serializer": "<5.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.3|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/property-access": "^4.4|^5.0|^6.0",
+                "symfony/routing": "^4.4|^5.0|^6.0",
+                "symfony/serializer": "^5.0|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/stopwatch": "^4.4|^5.0|^6.0",
+                "symfony/validator": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps applications send and receive messages to/from other applications or via message queues",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/messenger/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
             "name": "symfony/mime",
             "version": "v5.4.52",
             "source": {
@@ -4000,6 +4232,73 @@
                 }
             ],
             "time": "2024-11-25T16:14:41+00:00"
+        },
+        {
+            "name": "symfony/redis-messenger",
+            "version": "v5.4.48",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/redis-messenger.git",
+                "reference": "a097e8c6529a7179a732161bd5368629c6319899"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/redis-messenger/zipball/a097e8c6529a7179a732161bd5368629c6319899",
+                "reference": "a097e8c6529a7179a732161bd5368629c6319899",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/messenger": "^5.1|^6.0"
+            },
+            "require-dev": {
+                "symfony/property-access": "^4.4|^5.0|^6.0",
+                "symfony/serializer": "^4.4|^5.0|^6.0"
+            },
+            "type": "symfony-messenger-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\Bridge\\Redis\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Redis extension Messenger Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/redis-messenger/tree/v5.4.48"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-13T13:58:00+00:00"
         },
         {
             "name": "symfony/routing",

--- a/composer.lock
+++ b/composer.lock
@@ -6245,12 +6245,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da"
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7f0cd5d5ef89658ed1a56185bf33047477686fc5",
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5",
                 "shasum": ""
             },
             "require": {
@@ -6284,6 +6284,7 @@
                 "symfony/http-foundation": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/http-kernel": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mailer": "^5.4 | ^6.4 | ^7.4 | ^8.0",
+                "symfony/messenger": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mime": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/notifier": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/options-resolver": "^5.4 | ^6.4 | ^7.4 | ^8.0",
@@ -6343,7 +6344,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-23T20:14:24+00:00"
+            "time": "2026-06-25T19:43:59+00:00"
         },
         {
             "name": "codeception/stub",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,11 @@
+framework:
+    mailer:
+        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
+        # emails through the bus, which would double-count messages in MailerCest.
+        message_bus: false
+    messenger:
+        # A single synchronous bus; messages without explicit routing are handled in-process,
+        # which is what the Messenger assertions verify.
+        default_bus: messenger.bus.default
+        buses:
+            messenger.bus.default: ~

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,11 +1,7 @@
 framework:
     mailer:
-        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
-        # emails through the bus, which would double-count messages in MailerCest.
         message_bus: false
     messenger:
-        # A single synchronous bus; messages without explicit routing are handled in-process,
-        # which is what the Messenger assertions verify.
         default_bus: messenger.bus.default
         buses:
             messenger.bus.default: ~

--- a/config/routes.php
+++ b/config/routes.php
@@ -100,4 +100,8 @@ return static function (RoutingConfigurator $routes): void {
     $routes->add('app_create_user_with_confirmation', '/create-user-with-confirmation')
         ->controller(App\Controller\CreateUserWithConfirmationController::class)
         ->methods(['GET']);
+
+    $routes->add('dispatch_message', '/dispatch-message')
+        ->controller(App\Controller\DispatchMessageController::class)
+        ->methods(['GET']);
 };

--- a/src/Controller/DispatchMessageController.php
+++ b/src/Controller/DispatchMessageController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchMessageController extends AbstractController
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $this->bus->dispatch(new SendWelcomeMessage('jane_doe@example.com'));
+
+        return $this->json(['message' => 'Message dispatched']);
+    }
+}

--- a/src/Message/SendWelcomeMessage.php
+++ b/src/Message/SendWelcomeMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final class SendWelcomeMessage
+{
+    public function __construct(
+        private readonly string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SendWelcomeMessageHandler
+{
+    public function __invoke(SendWelcomeMessage $message): void
+    {
+        // No-op: the dispatch itself is what the assertions verify.
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -12,6 +12,5 @@ final class SendWelcomeMessageHandler
 {
     public function __invoke(SendWelcomeMessage $message): void
     {
-        // No-op: the dispatch itself is what the assertions verify.
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -438,6 +438,18 @@
             "./config/packages/mailer.yaml"
         ]
     },
+    "symfony/messenger": {
+        "version": "5.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.4",
+            "ref": "8bd5f27013fb1d7217191c548e340f0bdb11912c"
+        },
+        "files": [
+            "./config/packages/messenger.yaml"
+        ]
+    },
     "symfony/mime": {
         "version": "v5.1.8"
     },

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Message\SendWelcomeMessage;
+use App\Tests\Support\FunctionalTester;
+use stdClass;
+
+final class MessengerCest
+{
+    public function assertMessageCount(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->assertMessageCount(1);
+        $I->assertMessageCount(1, 'messenger.bus.default');
+    }
+
+    public function seeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->seeMessageDispatched(SendWelcomeMessage::class);
+        $I->seeMessageDispatched(SendWelcomeMessage::class, 'messenger.bus.default');
+    }
+
+    public function dontSeeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->dontSeeMessageDispatched(stdClass::class);
+    }
+
+    public function grabDispatchedMessageClasses(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $messages = $I->grabDispatchedMessageClasses();
+        $I->assertSame([SendWelcomeMessage::class], $messages);
+    }
+
+    public function noMessagesDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/');
+        $I->assertMessageCount(0);
+        $I->assertSame([], $I->grabDispatchedMessageClasses());
+    }
+}

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -10,11 +10,11 @@ use stdClass;
 
 final class MessengerCest
 {
-    public function assertMessageCount(FunctionalTester $I): void
+    public function seeDispatchedMessageCount(FunctionalTester $I): void
     {
         $I->amOnPage('/dispatch-message');
-        $I->assertMessageCount(1);
-        $I->assertMessageCount(1, 'messenger.bus.default');
+        $I->seeDispatchedMessageCount(1);
+        $I->seeDispatchedMessageCount(1, 'messenger.bus.default');
     }
 
     public function seeMessageDispatched(FunctionalTester $I): void
@@ -40,7 +40,7 @@ final class MessengerCest
     public function noMessagesDispatched(FunctionalTester $I): void
     {
         $I->amOnPage('/');
-        $I->assertMessageCount(0);
+        $I->seeDispatchedMessageCount(0);
         $I->assertSame([], $I->grabDispatchedMessageClasses());
     }
 }


### PR DESCRIPTION
Companion to **Codeception/module-symfony#241** (adds `MessengerAssertionsTrait`).

## What

Adds `tests/Functional/MessengerCest.php` exercising the new Messenger steps end-to-end:

- `seeDispatchedMessageCount(int, ?bus)`
- `seeMessageDispatched(class, ?bus)` / `dontSeeMessageDispatched(class, ?bus)`
- `grabDispatchedMessageClasses(?bus)`

## App changes

- Adds `symfony/messenger` and enables it with a single synchronous default bus (`messenger.bus.default`).
- Adds a sample `SendWelcomeMessage`, its handler, and a `/dispatch-message` controller/route the Cest hits.
- Sets `mailer.message_bus: false` so enabling Messenger does not route Mailer through the bus (which would otherwise double-count messages and break `MailerCest`).

Same change as the 7.4 PR (#53); validated there with `MessengerCest` 5/5 and `MailerCest`/`NotifierCest` green.

## CI is red until the module PR merges
These steps live in `codeception/module-symfony` (PR #241), which is not yet released. The app installs the module via `dev-main`, so `FunctionalTester` does not expose `seeDispatchedMessageCount` / `seeMessageDispatched` / `dontSeeMessageDispatched` / `grabDispatchedMessageClasses` yet — the `Call to undefined method ...` failures are expected pre-merge. Once #241 is merged to `main`, refreshing the lock (`composer update codeception/module-symfony`) makes this branch green.
