### PR TITLE
Add Messenger functional tests (8.1)

### DIFF
--- a/.env
+++ b/.env
@@ -20,8 +20,5 @@ NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
 
 ###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###

--- a/.env
+++ b/.env
@@ -18,3 +18,10 @@ MAILER_DSN=null://null
 ###> symfony/notifier ###
 NOTIFIER_DSN=null://null
 ###< symfony/notifier ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/framework-bundle": "8.1.*",
         "symfony/http-client": "8.1.*",
         "symfony/mailer": "8.1.*",
+        "symfony/messenger": "8.1.*",
         "symfony/notifier": "8.1.*",
         "symfony/runtime": "8.1.*",
         "symfony/security-bundle": "8.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -5863,12 +5863,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-symfony.git",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da"
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
-                "reference": "7d9317fe13da9e8521558f79b0fa3bd0a5c197da",
+                "url": "https://api.github.com/repos/Codeception/module-symfony/zipball/7f0cd5d5ef89658ed1a56185bf33047477686fc5",
+                "reference": "7f0cd5d5ef89658ed1a56185bf33047477686fc5",
                 "shasum": ""
             },
             "require": {
@@ -5902,6 +5902,7 @@
                 "symfony/http-foundation": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/http-kernel": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mailer": "^5.4 | ^6.4 | ^7.4 | ^8.0",
+                "symfony/messenger": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/mime": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/notifier": "^5.4 | ^6.4 | ^7.4 | ^8.0",
                 "symfony/options-resolver": "^5.4 | ^6.4 | ^7.4 | ^8.0",
@@ -5961,7 +5962,7 @@
                 "issues": "https://github.com/Codeception/module-symfony/issues",
                 "source": "https://github.com/Codeception/module-symfony/tree/main"
             },
-            "time": "2026-06-23T20:14:24+00:00"
+            "time": "2026-06-25T19:43:59+00:00"
         },
         {
             "name": "codeception/stub",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "daf25551631f2160dd16661390f08af8",
+    "content-hash": "14e30357887f3cf354c208f7d12e95ee",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -2827,6 +2827,98 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/mailer/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "c095398338a8e6f5ae6579ebb2092b7a16b7df72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/c095398338a8e6f5ae6579ebb2092b7a16b7df72",
+                "reference": "c095398338a8e6f5ae6579ebb2092b7a16b7df72",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/console": "<7.4",
+                "symfony/dependency-injection": "<8.1",
+                "symfony/event-dispatcher-contracts": "<2.5",
+                "symfony/lock": "<7.4",
+                "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4.4|^8.0.4",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps applications send and receive messages to/from other applications or via message queues",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/messenger/tree/v8.1.0"
             },
             "funding": [
                 {

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,11 @@
+framework:
+    mailer:
+        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
+        # emails through the bus, which would double-count messages in MailerCest.
+        message_bus: false
+    messenger:
+        # A single synchronous bus; messages without explicit routing are handled in-process,
+        # which is what the Messenger assertions verify.
+        default_bus: messenger.bus.default
+        buses:
+            messenger.bus.default: ~

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,11 +1,7 @@
 framework:
     mailer:
-        # Keep the Mailer synchronous: with Messenger enabled, Symfony otherwise routes
-        # emails through the bus, which would double-count messages in MailerCest.
         message_bus: false
     messenger:
-        # A single synchronous bus; messages without explicit routing are handled in-process,
-        # which is what the Messenger assertions verify.
         default_bus: messenger.bus.default
         buses:
             messenger.bus.default: ~

--- a/config/routes.php
+++ b/config/routes.php
@@ -100,4 +100,8 @@ return static function (RoutingConfigurator $routes): void {
     $routes->add('app_create_user_with_confirmation', '/create-user-with-confirmation')
         ->controller(App\Controller\CreateUserWithConfirmationController::class)
         ->methods(['GET']);
+
+    $routes->add('dispatch_message', '/dispatch-message')
+        ->controller(App\Controller\DispatchMessageController::class)
+        ->methods(['GET']);
 };

--- a/src/Controller/DispatchMessageController.php
+++ b/src/Controller/DispatchMessageController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchMessageController extends AbstractController
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $this->bus->dispatch(new SendWelcomeMessage('jane_doe@example.com'));
+
+        return $this->json(['message' => 'Message dispatched']);
+    }
+}

--- a/src/Message/SendWelcomeMessage.php
+++ b/src/Message/SendWelcomeMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final class SendWelcomeMessage
+{
+    public function __construct(
+        private readonly string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Message\SendWelcomeMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SendWelcomeMessageHandler
+{
+    public function __invoke(SendWelcomeMessage $message): void
+    {
+        // No-op: the dispatch itself is what the assertions verify.
+    }
+}

--- a/src/MessageHandler/SendWelcomeMessageHandler.php
+++ b/src/MessageHandler/SendWelcomeMessageHandler.php
@@ -12,6 +12,5 @@ final class SendWelcomeMessageHandler
 {
     public function __invoke(SendWelcomeMessage $message): void
     {
-        // No-op: the dispatch itself is what the assertions verify.
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -175,6 +175,18 @@
             "./config/packages/mailer.yaml"
         ]
     },
+    "symfony/messenger": {
+        "version": "8.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "d8936e2e2230637ef97e5eecc0eea074eecae58b"
+        },
+        "files": [
+            "./config/packages/messenger.yaml"
+        ]
+    },
     "symfony/notifier": {
         "version": "7.3",
         "recipe": {

--- a/tests/Functional/MessengerCest.php
+++ b/tests/Functional/MessengerCest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Message\SendWelcomeMessage;
+use App\Tests\Support\FunctionalTester;
+use stdClass;
+
+final class MessengerCest
+{
+    public function seeDispatchedMessageCount(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->seeDispatchedMessageCount(1);
+        $I->seeDispatchedMessageCount(1, 'messenger.bus.default');
+    }
+
+    public function seeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->seeMessageDispatched(SendWelcomeMessage::class);
+        $I->seeMessageDispatched(SendWelcomeMessage::class, 'messenger.bus.default');
+    }
+
+    public function dontSeeMessageDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $I->dontSeeMessageDispatched(stdClass::class);
+    }
+
+    public function grabDispatchedMessageClasses(FunctionalTester $I): void
+    {
+        $I->amOnPage('/dispatch-message');
+        $messages = $I->grabDispatchedMessageClasses();
+        $I->assertSame([SendWelcomeMessage::class], $messages);
+    }
+
+    public function noMessagesDispatched(FunctionalTester $I): void
+    {
+        $I->amOnPage('/');
+        $I->seeDispatchedMessageCount(0);
+        $I->assertSame([], $I->grabDispatchedMessageClasses());
+    }
+}


### PR DESCRIPTION
Companion to **Codeception/module-symfony#241** (adds `MessengerAssertionsTrait`).

## What

Adds `tests/Functional/MessengerCest.php` exercising the new Messenger steps end-to-end:

- `seeDispatchedMessageCount(int, ?bus)`
- `seeMessageDispatched(class, ?bus)` / `dontSeeMessageDispatched(class, ?bus)`
- `grabDispatchedMessageClasses(?bus)`

## App changes

- Adds `symfony/messenger` and enables it with a single synchronous default bus (`messenger.bus.default`).
- Adds a sample `SendWelcomeMessage`, its handler, and a `/dispatch-message` controller/route the Cest hits.
- Sets `mailer.message_bus: false` so enabling Messenger does not route Mailer through the bus (which would otherwise double-count messages and break `MailerCest`).

Validated locally against the module branch on Symfony 8.1: full `Functional` suite green (`MessengerCest` 5/5; `MailerCest`/`NotifierCest` unaffected).

## CI is red until the module PR merges
These steps live in `codeception/module-symfony` (PR #241), which is not yet released. The app installs the module via `dev-main`, so `FunctionalTester` does not expose the Messenger steps yet — the `Call to undefined method ...` failures are expected pre-merge. Once #241 is merged to `main`, refreshing the lock (`composer update codeception/module-symfony`) makes this branch green.
