### PR TITLE
[8.1] Add functional test for assertBrowserHistoryIsNotOnLastPage

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5630,16 +5630,16 @@
         },
         {
             "name": "codeception/lib-innerbrowser",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/lib-innerbrowser.git",
-                "reference": "8af7f8402f976b32f67a83dfd4e31f8f5b1f7db3"
+                "reference": "0fa80deaed7da6a92a0cd4117338394c69196ec6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/8af7f8402f976b32f67a83dfd4e31f8f5b1f7db3",
-                "reference": "8af7f8402f976b32f67a83dfd4e31f8f5b1f7db3",
+                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/0fa80deaed7da6a92a0cd4117338394c69196ec6",
+                "reference": "0fa80deaed7da6a92a0cd4117338394c69196ec6",
                 "shasum": ""
             },
             "require": {
@@ -5683,9 +5683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/lib-innerbrowser/issues",
-                "source": "https://github.com/Codeception/lib-innerbrowser/tree/4.1.0"
+                "source": "https://github.com/Codeception/lib-innerbrowser/tree/4.1.1"
             },
-            "time": "2026-02-07T10:09:13+00:00"
+            "time": "2026-06-26T22:06:27+00:00"
         },
         {
             "name": "codeception/lib-web",

--- a/tests/Functional/BrowserCest.php
+++ b/tests/Functional/BrowserCest.php
@@ -28,6 +28,14 @@ final class BrowserCest
         $I->assertBrowserHistoryIsNotOnFirstPage();
     }
 
+    public function assertBrowserHistoryIsNotOnLastPage(FunctionalTester $I)
+    {
+        $I->amOnPage('/');
+        $I->amOnPage('/login');
+        $I->moveBack();
+        $I->assertBrowserHistoryIsNotOnLastPage();
+    }
+
     public function assertBrowserHistoryIsOnFirstPage(FunctionalTester $I)
     {
         $I->amOnPage('/');


### PR DESCRIPTION
Adds the one missing functional test for the Symfony-inherited browser-history assertions introduced in **codeception/module-symfony#240** (`assertBrowserHistoryIsNotOnLastPage`). The sibling assertions (`IsNotOnFirstPage`, `IsOnFirstPage`, `IsOnLastPage`) were already covered by #45–#48; this one was omitted because no public step could position the browser history off the last page.

```php
public function assertBrowserHistoryIsNotOnLastPage(FunctionalTester $I)
{
    $I->amOnPage('/');
    $I->amOnPage('/login');
    $I->moveBack();
    $I->assertBrowserHistoryIsNotOnLastPage();
}
```

The assertion requires `symfony/browser-kit >= 7.4`, so it applies to the `7.4` and `8.1` branches only.

### Depends on Codeception/lib-innerbrowser#87
On released `lib-innerbrowser`, `moveBack()` replays the previous request with `changeHistory = true`, which re-appends to the history and leaves the pointer on the last page — so this test only passes once **Codeception/lib-innerbrowser#87** (move the history pointer instead of appending) is merged and released. CI here will be red until then.