### PR TITLE
[5.4] Verify assertBrowserHistoryIsNotOnLastPage is unavailable on browser-kit < 7.4

### DIFF
--- a/tests/Functional/BrowserCest.php
+++ b/tests/Functional/BrowserCest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Functional;
 
 use App\Entity\User;
 use App\Tests\Support\FunctionalTester;
+use PHPUnit\Framework\ExpectationFailedException;
 
 final class BrowserCest
 {
@@ -26,6 +27,18 @@ final class BrowserCest
         $I->setCookie('TESTCOOKIE', 'codecept');
         $I->resetCookie('TESTCOOKIE');
         $I->assertBrowserNotHasCookie('TESTCOOKIE');
+    }
+
+    public function assertBrowserHistoryIsNotOnLastPageRequiresBrowserKit74(FunctionalTester $I)
+    {
+        $I->amOnPage('/');
+
+        try {
+            $I->assertBrowserHistoryIsNotOnLastPage();
+            $I->fail('assertBrowserHistoryIsNotOnLastPage should fail when symfony/browser-kit < 7.4.');
+        } catch (ExpectationFailedException $e) {
+            $I->assertStringContainsString('requires symfony/browser-kit >= 7.4', $e->getMessage());
+        }
     }
 
     public function assertRequestAttributeValueSame(FunctionalTester $I)


### PR DESCRIPTION
Companion to #58 (7.4) and #59 (8.1). The `assertBrowserHistoryIsNotOnLastPage` assertion from **codeception/module-symfony#240** requires `symfony/browser-kit >= 7.4`. On Symfony 5.4 that constraint class does not exist, so the step is intentionally **unavailable** and the module guards it.

This test pins that documented behaviour: calling the step throws `PHPUnit\Framework\ExpectationFailedException` carrying the `requires symfony/browser-kit >= 7.4` message.

```php
public function assertBrowserHistoryIsNotOnLastPageRequiresBrowserKit74(FunctionalTester $I)
{
    $I->amOnPage('/');

    try {
        $I->assertBrowserHistoryIsNotOnLastPage();
        $I->fail('assertBrowserHistoryIsNotOnLastPage should fail when symfony/browser-kit < 7.4.');
    } catch (ExpectationFailedException $e) {
        $I->assertStringContainsString('requires symfony/browser-kit >= 7.4', $e->getMessage());
    }
}
```

No `composer.lock` bump needed here — the assertion is unavailable on this branch, so it does not depend on lib-innerbrowser 4.1.1. Validated locally against Symfony 5.4 (browser-kit v5.4.45).